### PR TITLE
Add Settings page + phase 2 preferences defaults

### DIFF
--- a/src/features/preferences/model/preferences.ts
+++ b/src/features/preferences/model/preferences.ts
@@ -1,0 +1,62 @@
+import { z } from 'zod'
+
+export type ZakatSchool = 'hanafi' | 'standard'
+
+export type UserPreferences = {
+  zakatSchool: ZakatSchool
+  currency: string
+  reminderDay: number
+  reminderTime: string
+  notificationsEnabled: boolean
+}
+
+const STORAGE_KEY = 'zakat-companion.preferences.v1'
+
+const preferencesSchema = z.object({
+  zakatSchool: z.enum(['hanafi', 'standard']).default('standard'),
+  currency: z
+    .string()
+    .trim()
+    .toUpperCase()
+    .length(3)
+    .default('EUR'),
+  reminderDay: z.number().int().min(1).max(28).default(10),
+  reminderTime: z
+    .string()
+    .regex(/^([01]\d|2[0-3]):([0-5]\d)$/)
+    .default('09:00'),
+  notificationsEnabled: z.boolean().default(true),
+})
+
+export const defaultPreferences: UserPreferences = {
+  zakatSchool: 'standard',
+  currency: 'EUR',
+  reminderDay: 10,
+  reminderTime: '09:00',
+  notificationsEnabled: true,
+}
+
+export function getPreferences(): UserPreferences {
+  if (typeof window === 'undefined') return defaultPreferences
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (!raw) return defaultPreferences
+
+    const parsed = preferencesSchema.safeParse(JSON.parse(raw))
+    if (!parsed.success) return defaultPreferences
+
+    return parsed.data
+  } catch {
+    return defaultPreferences
+  }
+}
+
+export function savePreferences(next: UserPreferences) {
+  if (typeof window === 'undefined') return
+
+  const parsed = preferencesSchema.safeParse(next)
+  if (!parsed.success) return
+
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(parsed.data))
+}

--- a/src/routes/onboarding/index.tsx
+++ b/src/routes/onboarding/index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useForm } from '@tanstack/react-form'
 import { z } from 'zod'
 import { IosAppShell } from '@/components/layout/ios-app-shell'
@@ -8,6 +8,7 @@ import { Card, CardDescription, CardHeader, CardTitle } from '@/components/ui/ca
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { getPreferences, savePreferences } from '@/features/preferences/model/preferences'
 import { m } from '@/paraglide/messages.js'
 
 type OnboardingValues = {
@@ -37,12 +38,13 @@ function fieldError(error: unknown, fallback: string) {
 
 function OnboardingPage() {
   const [savedState, setSavedState] = useState<OnboardingValues | null>(null)
+  const preferences = useMemo(() => getPreferences(), [])
 
   const defaultValues: OnboardingValues = {
     displayName: '',
-    zakatSchool: 'standard',
-    reminderDay: 10,
-    currency: 'EUR',
+    zakatSchool: preferences.zakatSchool,
+    reminderDay: preferences.reminderDay,
+    currency: preferences.currency,
   }
 
   const form = useForm({
@@ -51,6 +53,12 @@ function OnboardingPage() {
       onSubmit: onboardingSchema,
     },
     onSubmit: async ({ value }) => {
+      savePreferences({
+        ...preferences,
+        zakatSchool: value.zakatSchool,
+        reminderDay: value.reminderDay,
+        currency: value.currency,
+      })
       setSavedState(value)
     },
   })

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -1,7 +1,12 @@
 import { Link, createFileRoute } from '@tanstack/react-router'
+import { useMemo, useState } from 'react'
 import { IosAppShell } from '@/components/layout/ios-app-shell'
+import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { getPreferences, savePreferences, type UserPreferences } from '@/features/preferences/model/preferences'
 import { m } from '@/paraglide/messages.js'
 import { getLocale, locales, setLocale } from '@/paraglide/runtime.js'
 
@@ -17,9 +22,12 @@ function localeLabel(locale: (typeof locales)[number]) {
 
 function SettingsPage() {
   const activeLocale = getLocale()
+  const initialPreferences = useMemo(() => getPreferences(), [])
+  const [preferences, setPreferences] = useState<UserPreferences>(initialPreferences)
+  const [saved, setSaved] = useState(false)
 
   return (
-    <IosAppShell title="Preferences" subtitle="Language and app behavior" activeTab="profile">
+    <IosAppShell title="Preferences" subtitle="Language, reminder, and calculation defaults" activeTab="profile">
       <Card className="ios-surface">
         <CardHeader>
           <CardTitle className="ios-section-title">Language</CardTitle>
@@ -44,6 +52,89 @@ function SettingsPage() {
               ))}
             </SelectContent>
           </Select>
+        </CardContent>
+      </Card>
+
+      <Card className="ios-surface">
+        <CardHeader>
+          <CardTitle className="ios-section-title">Zakat defaults</CardTitle>
+          <CardDescription className="ios-copy-muted">Set your preferred defaults for onboarding and future calculations.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-2">
+            <Label>{m.onboarding_method_label()}</Label>
+            <Select
+              value={preferences.zakatSchool}
+              onValueChange={(value) => setPreferences((prev) => ({ ...prev, zakatSchool: value as UserPreferences['zakatSchool'] }))}
+            >
+              <SelectTrigger className="ios-input">
+                <SelectValue placeholder={m.onboarding_method_placeholder()} />
+              </SelectTrigger>
+              <SelectContent className="rounded-2xl">
+                <SelectItem value="standard">{m.onboarding_method_standard()}</SelectItem>
+                <SelectItem value="hanafi">{m.onboarding_method_hanafi()}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="grid gap-2">
+              <Label htmlFor="settings-currency">{m.onboarding_currency_label()}</Label>
+              <Input
+                id="settings-currency"
+                className="ios-input uppercase"
+                maxLength={3}
+                value={preferences.currency}
+                onChange={(event) => setPreferences((prev) => ({ ...prev, currency: event.target.value.toUpperCase() }))}
+              />
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="settings-day">{m.onboarding_day_label()}</Label>
+              <Input
+                id="settings-day"
+                className="ios-input"
+                type="number"
+                min={1}
+                max={28}
+                value={preferences.reminderDay}
+                onChange={(event) => setPreferences((prev) => ({ ...prev, reminderDay: Number(event.target.value || 1) }))}
+              />
+            </div>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="settings-time">Reminder time</Label>
+            <Input
+              id="settings-time"
+              className="ios-input"
+              type="time"
+              value={preferences.reminderTime}
+              onChange={(event) => setPreferences((prev) => ({ ...prev, reminderTime: event.target.value }))}
+            />
+          </div>
+
+          <label className="flex items-center justify-between rounded-2xl border border-white/70 bg-white/70 px-4 py-3 text-sm">
+            <span className="font-medium text-slate-700">Enable notifications</span>
+            <input
+              type="checkbox"
+              className="h-5 w-5 accent-slate-900"
+              checked={preferences.notificationsEnabled}
+              onChange={(event) => setPreferences((prev) => ({ ...prev, notificationsEnabled: event.target.checked }))}
+            />
+          </label>
+
+          <Button
+            type="button"
+            className="h-12 w-full rounded-2xl text-base shadow-[0_10px_24px_rgba(15,23,42,0.2)]"
+            onClick={() => {
+              savePreferences(preferences)
+              setSaved(true)
+              window.setTimeout(() => setSaved(false), 1500)
+            }}
+          >
+            {saved ? 'Saved' : 'Save preferences'}
+          </Button>
         </CardContent>
       </Card>
 


### PR DESCRIPTION
## Summary
- add a dedicated Settings/Preferences page linked from Profile
- move language selection into preferences flow
- remove bottom navbar underline indicator
- add persisted user preferences model (localStorage) for:
  - zakat method
  - default currency
  - reminder day
  - reminder time
  - notifications enabled
- wire onboarding defaults to saved preferences and sync updates on submit

## Validation
- npm run build passes
