### PR TITLE
fix(i18n): translate lifecycle UI labels (en/tr/nl)

### DIFF
--- a/src/routes/dashboard/history/index.tsx
+++ b/src/routes/dashboard/history/index.tsx
@@ -11,6 +11,7 @@ import { useLifecycleOverviewQuery } from '@/features/zakat/api/use-lifecycle-ov
 import { mapAssessmentHistoryRowToSnapshot } from '@/features/zakat/model/map-assessment-history-row'
 import { getPreferences } from '@/features/preferences/model/preferences'
 import { m } from '@/paraglide/messages.js'
+import { getLocale } from '@/paraglide/runtime.js'
 
 export const Route = createFileRoute('/dashboard/history/')({
   component: DashboardHistoryPage,
@@ -27,11 +28,45 @@ function formatDateTime(value?: string | Date | null) {
   }).format(date)
 }
 
-function timelineLabel(type: string) {
-  if (type === 'state_above') return 'Moved above nisab'
-  if (type === 'state_below') return 'Moved below nisab'
-  if (type === 'cycle_start') return 'Cycle started'
-  if (type === 'cycle_end') return 'Cycle ended'
+function tLifecycleHistory(locale: string) {
+  if (locale === 'tr') {
+    return {
+      timelineTitle: 'Döngü geçiş zaman çizelgesi',
+      empty: 'Henüz döngü geçişi yok.',
+      movedAbove: 'Nisab üstüne çıktı',
+      movedBelow: 'Nisab altına indi',
+      cycleStarted: 'Döngü başladı',
+      cycleEnded: 'Döngü bitti',
+    }
+  }
+
+  if (locale === 'nl') {
+    return {
+      timelineTitle: 'Tijdlijn van cyclusovergangen',
+      empty: 'Nog geen cyclusovergangen.',
+      movedAbove: 'Boven nisab gegaan',
+      movedBelow: 'Onder nisab gegaan',
+      cycleStarted: 'Cyclus gestart',
+      cycleEnded: 'Cyclus beëindigd',
+    }
+  }
+
+  return {
+    timelineTitle: 'Lifecycle transitions timeline',
+    empty: 'No lifecycle transitions yet.',
+    movedAbove: 'Moved above nisab',
+    movedBelow: 'Moved below nisab',
+    cycleStarted: 'Cycle started',
+    cycleEnded: 'Cycle ended',
+  }
+}
+
+function timelineLabel(type: string, locale: string) {
+  const t = tLifecycleHistory(locale)
+  if (type === 'state_above') return t.movedAbove
+  if (type === 'state_below') return t.movedBelow
+  if (type === 'cycle_start') return t.cycleStarted
+  if (type === 'cycle_end') return t.cycleEnded
   return type
 }
 
@@ -46,6 +81,8 @@ function DashboardHistoryPage() {
 
   const history = (historyQuery.data?.pages.flatMap((page) => page.items) ?? []).map(mapAssessmentHistoryRowToSnapshot)
   const timeline = lifecycleQuery.data?.timeline ?? []
+  const locale = getLocale()
+  const lifecycleT = tLifecycleHistory(locale)
 
   return (
     <AuthWrapper>
@@ -55,18 +92,18 @@ function DashboardHistoryPage() {
 
       <Card className="ios-surface">
         <CardHeader>
-          <CardTitle className="ios-section-title">Lifecycle transitions timeline</CardTitle>
+          <CardTitle className="ios-section-title">{lifecycleT.timelineTitle}</CardTitle>
         </CardHeader>
         <CardContent>
           {timeline.length === 0 ? (
             <div className="rounded-2xl border border-dashed border-slate-200 bg-white/70 px-4 py-4 text-sm text-slate-500">
-              No lifecycle transitions yet.
+              {lifecycleT.empty}
             </div>
           ) : (
             <div className="rounded-2xl border border-white/80 bg-white/85 px-3 divide-y divide-slate-200/70">
               {timeline.map((event) => (
                 <div key={event.id} className="py-3">
-                  <p className="text-sm font-semibold text-slate-900">{timelineLabel(event.type)}</p>
+                  <p className="text-sm font-semibold text-slate-900">{timelineLabel(event.type, locale)}</p>
                   <p className="text-xs text-slate-500">{formatDateTime(event.eventAt)}</p>
                 </div>
               ))}

--- a/src/routes/dashboard/index.tsx
+++ b/src/routes/dashboard/index.tsx
@@ -13,6 +13,7 @@ import { getPreferences } from '@/features/preferences/model/preferences'
 import { calculateZakat, formatMoney } from '@/features/zakat/model/calculate-zakat'
 import { getFinancialValues } from '@/features/zakat/model/financial-values'
 import { m } from '@/paraglide/messages.js'
+import { getLocale } from '@/paraglide/runtime.js'
 
 export const Route = createFileRoute('/dashboard/')({
   component: DashboardPage,
@@ -27,6 +28,39 @@ function formatDateTime(value?: string | Date | null) {
     dateStyle: 'medium',
     timeStyle: 'short',
   }).format(date)
+}
+
+function tLifecycleDashboard(locale: string) {
+  if (locale === 'tr') {
+    return {
+      title: 'Döngü',
+      currentState: 'Güncel nisab durumu',
+      activeCycle: 'Aktif döngü',
+      running: 'Devam ediyor',
+      notActive: 'Aktif değil',
+      nextDue: 'Sonraki vade tarihi',
+    }
+  }
+
+  if (locale === 'nl') {
+    return {
+      title: 'Cyclus',
+      currentState: 'Huidige nisab-status',
+      activeCycle: 'Actieve cyclus',
+      running: 'Actief',
+      notActive: 'Niet actief',
+      nextDue: 'Volgende vervaldatum',
+    }
+  }
+
+  return {
+    title: 'Lifecycle',
+    currentState: 'Current nisab state',
+    activeCycle: 'Active cycle',
+    running: 'Running',
+    notActive: 'Not active',
+    nextDue: 'Next due date',
+  }
 }
 
 function DashboardPage() {
@@ -55,6 +89,8 @@ function DashboardPage() {
 
   const userName = currentUser?.name?.trim() || m.onboarding_you()
   const lifecycle = lifecycleQuery.data
+  const locale = getLocale()
+  const lifecycleT = tLifecycleDashboard(locale)
 
   return (
     <AuthWrapper>
@@ -73,15 +109,15 @@ function DashboardPage() {
 
       <Card className="ios-surface">
         <CardHeader>
-          <CardTitle className="ios-section-title">Lifecycle</CardTitle>
+          <CardTitle className="ios-section-title">{lifecycleT.title}</CardTitle>
         </CardHeader>
         <CardContent className="space-y-2 text-sm">
           <SummaryRow
-            label="Current nisab state"
+            label={lifecycleT.currentState}
             value={(lifecycle?.currentNisabState ?? (result.isEligible ? 'ABOVE' : 'BELOW')) === 'ABOVE' ? m.nisab_state_above() : m.nisab_state_below()}
           />
-          <SummaryRow label="Active cycle" value={lifecycle?.hasActiveCycle ? 'Running' : 'Not active'} />
-          <SummaryRow label="Next due date" value={formatDateTime(lifecycle?.activeCycle?.nextDueAt ?? null)} />
+          <SummaryRow label={lifecycleT.activeCycle} value={lifecycle?.hasActiveCycle ? lifecycleT.running : lifecycleT.notActive} />
+          <SummaryRow label={lifecycleT.nextDue} value={formatDateTime(lifecycle?.activeCycle?.nextDueAt ?? null)} />
         </CardContent>
       </Card>
 


### PR DESCRIPTION
## Summary
- localize lifecycle summary labels on dashboard for English, Turkish, and Dutch
- localize lifecycle transitions timeline title/empty state/event labels on history page
- keep lifecycle behavior unchanged (UI text only)

## Validation
- npm run typecheck

## Why
The lifecycle feature shipped with English-only UI strings; this aligns it with the app's multilingual experience.
